### PR TITLE
Use gtk class suggested-action for more native looking buttons

### DIFF
--- a/src/gydl.py
+++ b/src/gydl.py
@@ -39,7 +39,7 @@ class GydlMessageGui(Gtk.Window):
         hBar  = Gtk.HeaderBar()
         Label = Gtk.Label(Title)
         Btn   = Gtk.Button(label="Done")
-        Btn.get_style_context().add_class("download")
+        Btn.get_style_context().add_class("suggested-action")
 
         # If a connection error occurs solely close the dialog
         if Title[0] == "C":
@@ -275,7 +275,7 @@ class GydlMainGui(Gtk.Window):
         bDownload = Gtk.Button(label="Download ")
         bDownload.connect("clicked", self.prepareDownload, Stack)
         bDownload.set_always_show_image(True)
-        bDownload.get_style_context().add_class("download")
+        bDownload.get_style_context().add_class("suggested-action")
         bDownload.set_image_position(Gtk.PositionType.RIGHT)
         bDownload.set_image(Gtk.Image.new_from_icon_name(
                             "folder-download-symbolic",
@@ -300,26 +300,6 @@ class GydlMainGui(Gtk.Window):
         return hBar
 
     def setStyle(self, Stack):
-
-        # Prepare the Css data
-        GydlStyle = ("""
-        button.download {
-            background: #5baad2;
-            color:      #ffffff;
-        }
-
-        button.download:hover {
-            background: #7ebedd;
-            color:      #ffffff;
-        }
-        """)
-
-        # Setup the CssProvider
-        cssProv = Gtk.CssProvider()
-        cssProv.load_from_data(bytes(GydlStyle.encode()))
-        Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(),
-                                                 cssProv,
-                                                 Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
         # Configure the stack transition
         Stack.set_transition_type(Gtk.StackTransitionType.SLIDE_LEFT_RIGHT)


### PR DESCRIPTION
Use gtk class suggested-action for more native looking blue buttons when using Adwaita or other GTK
themes.

# Before
![gydl-custom-css](https://cloud.githubusercontent.com/assets/1405445/25143111/2b985334-2461-11e7-8cfa-c496c7065e2b.png)

# After
![gydl-native](https://cloud.githubusercontent.com/assets/1405445/25143085/0d84ea1a-2461-11e7-88ac-2ddfbccac113.png)

