### PR TITLE
Add AppStream metadata

### DIFF
--- a/src/com.github.JannikHv.Gydl.appdata.xml
+++ b/src/com.github.JannikHv.Gydl.appdata.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Jannik Hauptvogel -->
+<component type="desktop-application">
+  <id>com.github.JannikHv.Gydl.desktop</id>
+  <name>Gydl</name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <summary>Downloads content from YouTube or other video platforms</summary>
+  <description>
+    <p>
+      Gydl (Graphical youtube-dl) is a tool that allows downloading of content from
+      YouTube and many other sites. It provides a simple dialog like interface for
+      quick and easy video or audio downloads without any disturbances.
+    </p>
+    <p>
+      Gydl is based upon the popular youtube-dl program, which can be found on GitHub.
+      A big thank you to the developer(s).
+    </p>
+  </description>
+  <url type="homepage">https://github.com/JannikHv/gydl</url>
+  <url type="bugtracker">https://github.com/JannikHv/gydl/issues</url>
+  <url type="help">https://github.com/JannikHv/gydl/blob/master/README.md</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://camo.githubusercontent.com/921825b3ea6ec9a765f8691a8cf866ca597d5d3b/687474703a2f2f692e696d6775722e636f6d2f6f3470595172582e706e67</image>
+    </screenshot>
+  </screenshots>
+</component>


### PR DESCRIPTION
AppStream metadata is used by Linux software centers to provide a description, screenshots, etc. It is also a requirement for Flatpak GUI applications.

See upstream documentation for specification:
https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html

You can use the following commands to validate the file:
```
appstream-util validate-relax com.github.JannikHv.Gydl.appdata.xml
appstream-util validate-strict com.github.JannikHv.Gydl.appdata.xml
```
The first is a requirement (currently passes), while the second is something to optionally strive for.