### PR TITLE
Fix variable undefined bug

### DIFF
--- a/src/gydl.py
+++ b/src/gydl.py
@@ -48,10 +48,10 @@ class GydlMessageGui(Gtk.Window):
     def getHeaderBar(self, Title, Image):
 
         # Configure the headerbar
-        hBar  = Gtk.HeaderBar()
-        Label = Gtk.Label(Title)
-        Btn   = Gtk.Button(label="Done")
-        Btn.get_style_context().add_class("suggested-action")
+        hBar   = Gtk.HeaderBar()
+        Label  = Gtk.Label(Title)
+        B_done = Gtk.Button(label="Done")
+        B_done.get_style_context().add_class("suggested-action")
 
         B_exit = Gtk.Button(label=" Exit ")
         B_exit.set_image(Image)


### PR DESCRIPTION
Pull request #04 introduced a bug, where the variable B_done was renamed to Btn but not in all places. A simple search and replace would have prevented this.

This fixes that by changing the name back to B_done which was more consistent with the rest of the code and at the same time fixes the aforementioned bug.