### PR TITLE
AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+install:
+  - sudo apt-get -y install libgtk-3-dev libav-tools
+
+script:
+  - make -j$(nproc)
+  - install -Dm 0755 /usr/bin/avprobe appdir/usr/bin/avprobe
+  - install -Dm 0755 /usr/bin/avconv appdir/usr/bin/avconv
+  - install -Dm 0644 data/com.github.JannikHv.Gydl.desktop appdir/usr/share/applications/gydl.desktop # FIXME
+  - install -Dm 0644 data/com.github.JannikHv.Gydl.appdata.xml appdir/usr/share/metainfo/com.github.JannikHv.Gydl.appdata.xml # FIXME
+  - install -Dm 0644 data/gydl.svg appdir/usr/share/icons/hicolor/scalable/apps/gydl.svg # FIXME
+  - install -Dm 0644 LICENSE appdir/usr/share/licenses/gydl/LICENSE # FIXME
+  - install -Dm 0755 gydl appdir/usr/bin/gydl # FIXME
+  - wget -c "https://yt-dl.org/downloads/latest/youtube-dl" -O appdir/usr/bin/youtube-dl
+  - |
+    cat > appdir/AppRun <<\EOF
+    #!/bin/bash
+    HERE=$(dirname $(readlink -f "${0}"))
+    export PATH=$HERE:$HERE/usr/bin:$PATH
+    exec "${HERE}/usr/bin/gydl" "$@"
+    EOF
+  - chmod a+rx appdir/usr/bin/youtube-dl appdir/AppRun
+  - find appdir/
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - |
+    ARCH=x86_64 ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage \
+    -exclude-libs=libgtk-3.so.0,libgdk-3.so.0 -executable=appdir/usr/bin/avprobe -executable=appdir/usr/bin/avconv
+
+after_success:
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh Gydl*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.