### PR TITLE
fix(appdata): add type to launchable

### DIFF
--- a/data/com.github.JannikHv.Gydl.appdata.xml.in
+++ b/data/com.github.JannikHv.Gydl.appdata.xml.in
@@ -22,7 +22,7 @@
       A big thank you to the developer(s).
     </p>
   </description>
-  <launchable>com.github.JannikHv.Gydl.desktop</launchable>
+  <launchable type="desktop-id">com.github.JannikHv.Gydl.desktop</launchable>
   <url type="homepage">https://github.com/JannikHv/gydl</url>
   <url type="bugtracker">https://github.com/JannikHv/gydl/issues</url>
   <url type="help">https://github.com/JannikHv/gydl/blob/master/README.md</url>


### PR DESCRIPTION
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable

Seems like this is mandatory now and error during build in Fedora 34 https://kojipkgs.fedoraproject.org//work/tasks/2436/60592436/build.log